### PR TITLE
`LeftJoinModel`/`WritableProxyModel` fixes/imporvements

### DIFF
--- a/testlib/include/qtmodelstoolkit/testing/testmodel.h
+++ b/testlib/include/qtmodelstoolkit/testing/testmodel.h
@@ -7,6 +7,7 @@ namespace qtmt {
 class TestModel : public QAbstractListModel {
 
 public:
+    TestModel() = default;
     explicit TestModel(QList<QPair<QString, QVariantList>> data);
     explicit TestModel(QList<QString> roles);
 
@@ -30,6 +31,9 @@ public:
 
     // emits modelAboutToBeReset/modelReset, content remains the same
     void reset();
+
+    // emits modelAboutToBeReset/modelReset, sets new roles and data
+    void reset(QList<QPair<QString, QVariantList>> data);
 
     // emits modelAboutToBeReset/modelReset, content is removed
     void resetAndClear();

--- a/testlib/src/testmodel.cpp
+++ b/testlib/src/testmodel.cpp
@@ -136,6 +136,14 @@ void TestModel::reset()
     endResetModel();
 }
 
+void TestModel::reset(QList<QPair<QString, QVariantList>> data)
+{
+    beginResetModel();
+    m_data = std::move(data);
+    initRoles();
+    endResetModel();
+}
+
 void TestModel::resetAndClear()
 {
     beginResetModel();
@@ -147,6 +155,7 @@ void TestModel::resetAndClear()
 
 void TestModel::initRoles()
 {
+    m_roles.clear();
     m_roles.reserve(m_data.size());
 
     for (auto i = 0; i < m_data.size(); i++)

--- a/toolkit/include/qtmodelstoolkit/leftjoinmodel.h
+++ b/toolkit/include/qtmodelstoolkit/leftjoinmodel.h
@@ -2,14 +2,12 @@
 
 #include <QAbstractListModel>
 #include <QPointer>
-#include <QQmlParserStatus>
 
 namespace qtmt {
 
-class LeftJoinModel : public QAbstractListModel, public QQmlParserStatus
+class LeftJoinModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(QAbstractItemModel* leftModel READ leftModel
                WRITE setLeftModel NOTIFY leftModelChanged)
@@ -42,9 +40,6 @@ public:
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
 
-    void classBegin() override;
-    void componentComplete() override;
-
 signals:
     void leftModelChanged();
     void rightModelChanged();
@@ -62,6 +57,7 @@ private:
     QHash<int, QByteArray> m_leftRoleNames;
     QHash<int, QByteArray> m_rightRoleNames;
     QHash<int, QByteArray> m_roleNames;
+    mutable bool m_rolesFetched = false;
     QVector<int> m_joinedRoles;
 
     QString m_joinRole;

--- a/toolkit/src/writableproxymodel.cpp
+++ b/toolkit/src/writableproxymodel.cpp
@@ -203,8 +203,11 @@ void WritableProxyModelPrivate::createProxyToSourceRowMap()
     auto sourceModel = q.sourceModel();
 
     proxyToSourceRowMapping.clear();
+
+    auto rowCount = q.rowCount();
     int sourceIter = 0;
-    for (int i = 0; i < q.rowCount(); ++i) {
+
+    for (int i = 0; i < rowCount; ++i) {
         if (insertedRows.contains(q.index(i, 0)))
         {
             proxyToSourceRowMapping.append(-1);
@@ -732,7 +735,7 @@ void WritableProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
     connect(sourceModel, &QAbstractItemModel::rowsAboutToBeMoved, this, &WritableProxyModel::onRowsAboutToBeMoved);
     connect(sourceModel, &QAbstractItemModel::rowsMoved, this, &WritableProxyModel::onRowsMoved);
     connect(sourceModel, &QAbstractItemModel::layoutAboutToBeChanged, this, &WritableProxyModel::onLayoutAboutToBeChanged);
-    connect(sourceModel, &QAbstractItemModel::layoutChanged, this, &WritableProxyModel::onModelReset);
+    connect(sourceModel, &QAbstractItemModel::layoutChanged, this, &WritableProxyModel::onLayoutChanged);
 
     endResetModel();
 }


### PR DESCRIPTION
# What does the PR do

- `TestModel`:
  - added possibility to init empty (no data nor roles)
  - added possibility to reset with setting different roles/data
- `LeftJoinModel`:
   - proper handling of source models reset (left and right) when the model is not fully initialized
   - removed QQmlParserStatus inheritance
   - emiting model reset only if needed to simplify upstream models nitialization
   - tests amended
- `WritablePRoxyModel`:
   - layout change handling fixed