### PR TITLE
SFPM compatibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ create custom models in C++.
 
 The library was originally created as part of the
 [Status Desktop](https://github.com/status-im/status-desktop) project, then
-split off into a separate repository.
+split off into a separate repository. The earlier git history of the toolkit
+can be found in Status Desktop repository at that [point](https://github.com/status-im/status-desktop/tree/06ec58e2e47b88bf213f2fc6f6950b9ecfb216c9).
 
 Online documentation can be found here: https://status-im.github.io/QtModelsToolkit/
+
+> [!IMPORTANT]  
+> This library works great with the [SFPM](https://github.com/oKcerG/SortFilterProxyModel)
+> library, but it's best to use a [patched version](https://github.com/status-im/SortFilterProxyModel)
+> that includes many fixes that ensure both libraries work together seamlessly.
 
 ## Features
 
@@ -31,7 +37,7 @@ Online documentation can be found here: https://status-im.github.io/QtModelsTool
   
 - **GroupingModel**
   A proxy model that groups items from a source model based on value of role
-  specified as grouping role.
+  specified as the grouping role.
   
 - **ObjectProxyModel**
   Swiss Army knife of proxy models. It allows to create new roles and modify
@@ -134,7 +140,9 @@ add_subdirectory(vendor/QtModelsToolkit)
 target_link_libraries(<YourTarget> QtModelsToolkit)
 ```
 
-Sample project is available here: https://github.com/status-im/QtModelsToolkit-Example
+A sample project is available here: https://github.com/status-im/QtModelsToolkit-Example.
+Also [Status Desktop](https://github.com/status-im/status-desktop) is a great
+source of examples, where the toolkit is used in a real app.
 
 ## License
 

--- a/demoapp/CMakeLists.txt
+++ b/demoapp/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
   SortFilterProxyModel
   GIT_REPOSITORY https://github.com/status-im/SortFilterProxyModel.git
-  GIT_TAG master
+  GIT_TAG 6477b1e465b02f18007900125864cdfa812ba8ad
 )
 
 FetchContent_MakeAvailable(SortFilterProxyModel)

--- a/testlib/include/qtmodelstoolkit/testing/testmodel.h
+++ b/testlib/include/qtmodelstoolkit/testing/testmodel.h
@@ -16,6 +16,15 @@ public:
     QVariant data(const QModelIndex& index, int role) const override;
 
     void insert(int index, QVariantList row);
+    void append(QVariantList row);
+
+    // intened to be used only when the model has no role names specified,
+    // to mimic behavior of first insertion/append to an empty ListModel,
+    // described in https://bugreports.qt.io/browse/QTBUG-57971. The model emits
+    // rowsAboutToBeInserted/rowsInserted with changed roleNames, without
+    // issuing model reset.
+    void appendAndInitRoles(QList<QPair<QString, QVariantList>> data);
+
     void update(int index, int role, QVariant value);
     void remove(int index);
 
@@ -35,7 +44,8 @@ public:
     // emits modelAboutToBeReset/modelReset, sets new roles and data
     void reset(QList<QPair<QString, QVariantList>> data);
 
-    // emits modelAboutToBeReset/modelReset, content is removed
+    // emits modelAboutToBeReset/modelReset, content is removed, roles remain the
+    // same
     void resetAndClear();
 
 private:

--- a/testlib/src/testmodel.cpp
+++ b/testlib/src/testmodel.cpp
@@ -27,8 +27,7 @@ int TestModel::rowCount(const QModelIndex& parent) const
     if(parent.isValid())
         return 0;
 
-    Q_ASSERT(m_data.size());
-    return m_data.first().second.size();
+    return m_data.isEmpty() ? 0 : m_data.first().second.size();
 }
 
 QHash<int, QByteArray> TestModel::roleNames() const
@@ -61,6 +60,24 @@ void TestModel::insert(int index, QVariantList row)
         roleVariantList.insert(index, std::move(row[i]));
     }
 
+    endInsertRows();
+}
+
+void TestModel::append(QVariantList row)
+{
+    insert(rowCount(), std::move(row));
+}
+
+void TestModel::appendAndInitRoles(QList<QPair<QString, QVariantList>> data)
+{
+    Q_ASSERT(m_roles.empty());
+    Q_ASSERT(m_data.empty());
+    Q_ASSERT(!data.empty());
+    Q_ASSERT(!data.at(0).second.empty());
+
+    beginInsertRows(QModelIndex{}, 0, data.at(0).second.size());
+    m_data = std::move(data);
+    initRoles();
     endInsertRows();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,3 +77,7 @@ add_test(NAME GroupingModelTest COMMAND GroupingModelTest)
 add_executable(ModelCountTest tst_ModelCount.cpp)
 target_link_libraries(ModelCountTest ${PROJECT_NAME} ${PROJECT_NAME}TestLib)
 add_test(NAME ModelCountTest COMMAND ModelCountTest)
+
+add_executable(SortFilterProxyModelTest tst_SortFilterProxyModel.cpp)
+target_link_libraries(SortFilterProxyModelTest ${PROJECT_NAME} ${PROJECT_NAME}TestLib SortFilterProxyModel)
+add_test(NAME SortFilterProxyModelTest COMMAND SortFilterProxyModelTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   SortFilterProxyModel
   GIT_REPOSITORY https://github.com/status-im/SortFilterProxyModel.git
-  GIT_TAG master
+  GIT_TAG 6477b1e465b02f18007900125864cdfa812ba8ad
 )
 
 FetchContent_MakeAvailable(SortFilterProxyModel)

--- a/tests/tst_Aggregator.cpp
+++ b/tests/tst_Aggregator.cpp
@@ -1,4 +1,5 @@
-#include <QtTest>
+#include <QTest>
+#include <QSignalSpy>
 
 #include <qtmodelstoolkit/aggregator.h>
 #include <qtmodelstoolkit/testing/testmodel.h>

--- a/tests/tst_FunctionAggregator.cpp
+++ b/tests/tst_FunctionAggregator.cpp
@@ -1,4 +1,4 @@
-#include <QtTest>
+#include <QTest>
 
 #include <QQmlEngine>
 

--- a/tests/tst_ModelCount.cpp
+++ b/tests/tst_ModelCount.cpp
@@ -1,4 +1,5 @@
-#include <QtTest>
+#include <QTest>
+#include <QSignalSpy>
 
 #include <qtmodelstoolkit/modelcount.h>
 

--- a/tests/tst_ModelQuery.cpp
+++ b/tests/tst_ModelQuery.cpp
@@ -1,4 +1,4 @@
-#include <QtTest>
+#include <QTest>
 
 #include <QQmlEngine>
 

--- a/tests/tst_ModelSyncedContainer.cpp
+++ b/tests/tst_ModelSyncedContainer.cpp
@@ -1,5 +1,9 @@
-#include <QtTest>
+#include <QTest>
 #include <QQmlEngine>
+
+#include <QIdentityProxyModel>
+#include <QJsonArray>
+#include <QJsonObject>
 
 #include <qtmodelstoolkit/modelsyncedcontainer.h>
 

--- a/tests/tst_SingleRoleAggregator.cpp
+++ b/tests/tst_SingleRoleAggregator.cpp
@@ -1,4 +1,5 @@
-#include <QtTest>
+#include <QTest>
+#include <QSignalSpy>
 
 #include <qtmodelstoolkit/singleroleaggregator.h>
 #include <qtmodelstoolkit/testing/testmodel.h>

--- a/tests/tst_SortFilterProxyModel.cpp
+++ b/tests/tst_SortFilterProxyModel.cpp
@@ -1,0 +1,263 @@
+#include <QTest>
+
+#include <qtmodelstoolkit/testing/testmodel.h>
+#include <qtmodelstoolkit/testing/modelsignalsspy.h>
+#include <qtmodelstoolkit/testing/modeltestutils.h>
+
+#include <qqmlsortfilterproxymodel.h>
+#include <proxyroles/joinrole.h>
+
+using namespace qtmt;
+using SFPM = qqsfpm::QQmlSortFilterProxyModel;
+
+class TestSortFilterProxyModel : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void basicInitTest()
+    {
+        SFPM sfpm;
+
+        TestModel sourceModel({
+            { "name", { "name 1_1", "name 1_2", "name 1_3", "name 1_4" }}
+        });
+
+        ModelSignalsSpy signalsSpy(&sfpm);
+        QCOMPARE(signalsSpy.count(), 0);
+
+        {
+            QObject context;
+            connect(&sfpm, &SFPM::modelAboutToBeReset, &context,
+                    [&sfpm] {
+                QCOMPARE(sfpm.roleNames().size(), 0);
+                QCOMPARE(sfpm.rowCount(), 0);
+            });
+
+            sfpm.setSourceModel(&sourceModel);
+        }
+
+        QCOMPARE(signalsSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
+        QVERIFY(isSame(sourceModel, sfpm));
+    }
+
+    void initWithEmptyModelWithNoRolesTest()
+    {
+        SFPM sfpm;
+
+        TestModel sourceModel;
+
+        ModelSignalsSpy signalsSpy(&sfpm);
+        QCOMPARE(signalsSpy.count(), 0);
+
+        sfpm.setSourceModel(&sourceModel);
+
+        QCOMPARE(signalsSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
+        QVERIFY(isSame(sourceModel, sfpm));
+
+        {
+            QObject context;
+            connect(&sfpm, &SFPM::modelAboutToBeReset, &context,
+                    [&sfpm] {
+                        QCOMPARE(sfpm.roleNames().size(), 0);
+                        QCOMPARE(sfpm.rowCount(), 0);
+                    });
+
+            sourceModel.appendAndInitRoles({
+                { "name", { "name 1_1", "name 1_2", "name 1_3", "name 1_4" }}
+            });
+        }
+
+        QCOMPARE(signalsSpy.count(), 4);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 2);
+        QVERIFY(isSame(sourceModel, sfpm));
+
+        {
+            QObject context;
+            connect(&sfpm, &SFPM::rowsAboutToBeInserted, &context,
+                    [&sfpm] {
+                        QCOMPARE(sfpm.roleNames().size(), 1);
+                        QCOMPARE(sfpm.rowCount(), 4);
+                    });
+
+            sourceModel.append({ "name 1_5" });
+        }
+
+        QCOMPARE(signalsSpy.count(), 6);
+        QCOMPARE(signalsSpy.rowsAboutToBeInsertedSpy.count(), 1);
+        QCOMPARE(signalsSpy.rowsInsertedSpy.count(), 1);
+        QCOMPARE(sfpm.rowCount(), 5);
+    }
+
+    void initWithEmptyModelAndClearSourceTest()
+    {
+        SFPM sfpm;
+
+        TestModel sourceModel;
+        ModelSignalsSpy signalsSpy(&sfpm);
+        QCOMPARE(signalsSpy.count(), 0);
+
+        sfpm.setSourceModel(&sourceModel);
+
+        QCOMPARE(signalsSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
+        QVERIFY(isSame(sourceModel, sfpm));
+
+        sfpm.setSourceModel(nullptr);
+        QCOMPARE(signalsSpy.count(), 4);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 2);
+
+        // make sure that actions on the source don't affect the sfpm (that
+        // signals are properly disconnected internally)
+        sourceModel.appendAndInitRoles({
+            { "name", { "name 1_1", "name 1_2", "name 1_3", "name 1_4" }}
+        });
+
+        QCOMPARE(signalsSpy.count(), 4);
+    }
+
+    void initWithEmptyModelAndResetSourceTest()
+    {
+        SFPM sfpm;
+
+        TestModel sourceModel;
+        ModelSignalsSpy signalsSpy(&sfpm);
+        QCOMPARE(signalsSpy.count(), 0);
+
+        sfpm.setSourceModel(&sourceModel);
+
+        QCOMPARE(signalsSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
+        QVERIFY(isSame(sourceModel, sfpm));
+
+        // reset source to have roles defined, no content
+        {
+            QObject context;
+            connect(&sfpm, &SFPM::modelAboutToBeReset, &context,
+                    [&sfpm] {
+                        QCOMPARE(sfpm.roleNames().size(), 0);
+                        QCOMPARE(sfpm.rowCount(), 0);
+                    });
+
+            sourceModel.reset({
+                { "name", {}}
+            });
+        }
+
+        QCOMPARE(signalsSpy.count(), 4);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 2);
+
+        // insertion should be handled in standard way, no model reset
+        {
+            QObject context;
+            connect(&sfpm, &SFPM::rowsAboutToBeInserted, &context,
+                    [&sfpm] {
+                        QCOMPARE(sfpm.roleNames().size(), 1);
+                        QCOMPARE(sfpm.rowCount(), 0);
+                    });
+
+            sourceModel.append({ "name_1" });
+        }
+
+        QCOMPARE(signalsSpy.count(), 6);
+        QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy.modelResetSpy.count(), 2);
+        QCOMPARE(signalsSpy.rowsAboutToBeInsertedSpy.count(), 1);
+        QCOMPARE(signalsSpy.rowsInsertedSpy.count(), 1);
+        QCOMPARE(sfpm.count(), 1);
+    }
+
+    void changingSourceOnChainedSfpmTest()
+    {
+        SFPM sfpm_1;
+        SFPM sfpm_2;
+
+        ModelSignalsSpy signalsSpy_1(&sfpm_1);
+        ModelSignalsSpy signalsSpy_2(&sfpm_2);
+
+        sfpm_2.setSourceModel(&sfpm_1);
+
+        QCOMPARE(signalsSpy_1.count(), 0);
+        QCOMPARE(signalsSpy_2.count(), 2);
+        QCOMPARE(signalsSpy_2.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy_2.modelResetSpy.count(), 1);
+
+        TestModel sourceModel_1;
+        TestModel sourceModel_2;
+
+        sfpm_1.setSourceModel(&sourceModel_1);
+
+        QCOMPARE(signalsSpy_1.count(), 2);
+        QCOMPARE(signalsSpy_1.modelAboutToBeResetSpy.count(), 1);
+        QCOMPARE(signalsSpy_1.modelResetSpy.count(), 1);
+        QCOMPARE(signalsSpy_2.count(), 4);
+        QCOMPARE(signalsSpy_2.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy_2.modelResetSpy.count(), 2);
+
+        sourceModel_1.appendAndInitRoles({
+            { "name", { "name 1_1", "name 1_2", "name 1_3", "name 1_4" }}
+        });
+
+        QCOMPARE(signalsSpy_1.count(), 4);
+        QCOMPARE(signalsSpy_1.modelAboutToBeResetSpy.count(), 2);
+        QCOMPARE(signalsSpy_1.modelResetSpy.count(), 2);
+        QCOMPARE(signalsSpy_2.count(), 6);
+        QCOMPARE(signalsSpy_2.modelAboutToBeResetSpy.count(), 3);
+        QCOMPARE(signalsSpy_2.modelResetSpy.count(), 3);
+        QCOMPARE(sfpm_1.roleNames().count(), 1);
+        QCOMPARE(sfpm_2.roleNames().count(), 1);
+
+        sfpm_1.setSourceModel(&sourceModel_2);
+
+        QCOMPARE(signalsSpy_1.count(), 6);
+        QCOMPARE(signalsSpy_1.modelAboutToBeResetSpy.count(), 3);
+        QCOMPARE(signalsSpy_1.modelResetSpy.count(), 3);
+        QCOMPARE(signalsSpy_2.count(), 8);
+        QCOMPARE(signalsSpy_2.modelAboutToBeResetSpy.count(), 4);
+        QCOMPARE(signalsSpy_2.modelResetSpy.count(), 4);
+        QCOMPARE(sfpm_1.roleNames().count(), 0);
+        QCOMPARE(sfpm_2.roleNames().count(), 0);
+
+        sourceModel_2.appendAndInitRoles({
+            { "name", { "name 1_1", "name 1_2" }},
+            { "subname", { "subname 1_1", "subname 1_2" }}
+        });
+
+        QCOMPARE(signalsSpy_1.count(), 8);
+        QCOMPARE(signalsSpy_1.modelAboutToBeResetSpy.count(), 4);
+        QCOMPARE(signalsSpy_1.modelResetSpy.count(), 4);
+        QCOMPARE(signalsSpy_2.count(), 10);
+        QCOMPARE(signalsSpy_2.modelAboutToBeResetSpy.count(), 5);
+        QCOMPARE(signalsSpy_2.modelResetSpy.count(), 5);
+        QCOMPARE(sfpm_1.roleNames().count(), 2);
+        QCOMPARE(sfpm_2.roleNames().count(), 2);
+    }
+
+    void connectionsCleanupTest()
+    {
+        // This test would crash in case of lack of internal connections
+        // cleanup, triggering actions on the destroyed object.
+        TestModel sourceModel;
+
+        {
+            SFPM sfpm;
+            sfpm.setSourceModel(&sourceModel);
+        }
+
+        sourceModel.appendAndInitRoles({
+            { "name", { "name 1_1", "name 1_2", "name 1_3", "name 1_4" }}
+        });
+    }
+};
+
+QTEST_MAIN(TestSortFilterProxyModel)
+#include "tst_SortFilterProxyModel.moc"

--- a/tests/tst_SumAggregator.cpp
+++ b/tests/tst_SumAggregator.cpp
@@ -1,4 +1,5 @@
-#include <QtTest>
+#include <QTest>
+#include <QSignalSpy>
 
 #include <qtmodelstoolkit/sumaggregator.h>
 #include <qtmodelstoolkit/testing/testmodel.h>


### PR DESCRIPTION
# What does this PR do

- adds tests for SPFM intended to be used with that library  https://github.com/status-im/SortFilterProxyModel regarding aspects important for seamless interoperability between those two libraries. In case of using other version of SFPM, those test should pass to ensure good interoperability.
- extends `TestModel` test utility
- updates README