### PR TITLE
perf(LeftJoinModel): Add LRU cache for right model data access

### DIFF
--- a/tests/tst_ConcatModel.cpp
+++ b/tests/tst_ConcatModel.cpp
@@ -1804,12 +1804,12 @@ private slots:
                 });
 
                 connect(&model, &ConcatModel::rowsRemoved, &context,
-                        [this, &model, &roles] {
+                        [&model] {
                     QCOMPARE(model.rowCount(), 0);
                 });
 
                 connect(&model, &ConcatModel::rowsAboutToBeInserted, &context,
-                        [this, &model, &roles] {
+                        [&model] {
                     QCOMPARE(model.rowCount(), 0);
                 });
 

--- a/tests/tst_LeftJoinModel.cpp
+++ b/tests/tst_LeftJoinModel.cpp
@@ -1322,6 +1322,118 @@ private slots:
         QCOMPARE(model.roleNames(), roles);
         QCOMPARE(model.rowCount(), 3);
     }
+
+    void cacheTest()
+    {
+        TestModel leftModel({
+           { "id", { "1", "2", "3", "4" }},
+           { "communityId", { "c1", "c2", "c3", "c4" }}
+        });
+
+        TestModel rightModel({
+           { "name", { "Community 1", "Community 2", "Community 3", "Community 4" }},
+           { "communityId", { "c1", "c2", "c3", "c4" }}
+        });
+
+        LeftJoinModel model;
+        model.setCacheSize(2);
+        QCOMPARE(model.cacheSize(), 2);
+
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        // Access item 0 -> cache: [c1]
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+
+        // Access item 1 -> cache: [c2, c1]
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+
+        // Access item 0 again -> cache: [c1, c2]
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+
+        // Access item 2 -> cache: [c3, c1], item c2 is evicted
+        QCOMPARE(model.data(model.index(2, 0), 2), QString("Community 3"));
+
+        // Access item 3 -> cache: [c4, c3], item c1 is evicted
+        QCOMPARE(model.data(model.index(3, 0), 2), QString("Community 4"));
+
+        // Now, if we access item 1, it should be a cache miss and it will be fetched.
+        // This will evict item c3. cache: [c2, c4]
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+
+        // Check that cache is cleared when right model is reset
+        rightModel.reset({
+           { "name", { "C1", "C2", "C3", "C4" }},
+           { "communityId", { "c1", "c2", "c3", "c4" }}
+        });
+
+        // Accessing item 1 again should give the new value
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("C2"));
+    }
+
+    void benchmarkDataAccess_data()
+    {
+        QTest::addColumn<bool>("useCache");
+        QTest::newRow("with cache") << true;
+        QTest::newRow("without cache") << false;
+    }
+
+    void benchmarkDataAccess()
+    {
+        QFETCH(bool, useCache);
+
+        const int rowCount = 10000;
+        QVariantList leftIds, leftCommunityIds;
+        for(int i = 0; i < rowCount; ++i) {
+            leftIds << QString("Token %1").arg(i);
+            leftCommunityIds << QString("community_%1").arg(i);
+        }
+
+        TestModel leftModel({
+           { "title", leftIds },
+           { "communityId", leftCommunityIds }
+        });
+
+        QVariantList rightNames, rightCommunityIds;
+        for(int i = 0; i < rowCount; ++i) {
+            rightNames << QString("Community %1").arg(i);
+            rightCommunityIds << QString("community_%1").arg(i);
+        }
+
+        TestModel rightModel({
+           { "name", rightNames },
+           { "communityId", rightCommunityIds }
+        });
+
+        LeftJoinModel model;
+        if (useCache) {
+            model.setCacheSize(10000);
+        } else {
+            // A size of 1 is the minimal QCache size that does something,
+            // but it's effectively "no real cache" for random access.
+            // It behaves similarly to the original m_lastUsedRightModelIndex.
+            model.setCacheSize(1);
+        }
+
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QCOMPARE(model.rowCount(), rowCount);
+
+        // Role for 'name' from the right model
+        const int nameRole = model.roleNames().key("name");
+
+        QBENCHMARK {
+            for (int i = 0; i < 5; ++i) {
+                for (int j = 0; j < 1000; ++j) { // Access each item 1000 times
+                    int rowIndex = rowCount - j;
+                    model.data(model.index(rowIndex, 0), nameRole);
+                }
+            }
+        }
+    }
 };
 
 QTEST_MAIN(TestLeftJoinModel)

--- a/tests/tst_WritableProxyModel.cpp
+++ b/tests/tst_WritableProxyModel.cpp
@@ -111,7 +111,7 @@ public:
         endInsertRows();
     }
 
-    void insertRows(int index, const QList<QPair<QString, QVariantList>>& data)
+    void insertTestRows(int index, const QList<QPair<QString, QVariantList>>& data)
     {
         if (data.isEmpty() || data.at(0).second.isEmpty())
             return;
@@ -521,7 +521,7 @@ private slots:
         QCOMPARE(dataChangedSpy.first().at(1), model.index(0, 0));
 
         model.setData(model.index(0, 0), "Token 1.2", 0);
-        
+
         QCOMPARE(model.rowCount(), 2);
         QCOMPARE(model.dirty(), true);
         QCOMPARE(model.data(model.index(0, 0), 0), "Token 1.2");
@@ -537,7 +537,7 @@ private slots:
         QCOMPARE(dataChangedSpy.count(), 2);
 
         sourceModel.setData(sourceModel.index(0, 0), "community_1.1", 1);
-        
+
         //other roles can change
         QCOMPARE(model.dirty(), true);
         QCOMPARE(model.data(model.index(0, 0), 1), "community_1.1");
@@ -757,7 +757,7 @@ private slots:
         QCOMPARE(model.syncedRemovals(), true);
 
         model.setData(model.index(0, 0), "Token 1.1", 0);
-        
+
         QCOMPARE(model.dirty(), true);
         QCOMPARE(model.rowCount(), 3);
 
@@ -830,7 +830,7 @@ private slots:
 
         QCOMPARE(model.dirty(), true);
         QCOMPARE(model.rowCount(), 2);
-        
+
         QCOMPARE(rowsRemovedSpy.count(), 0);
         QCOMPARE(modelResetSpy.count(), 1);
         QCOMPARE(dataChangedSpy.count(), 1);
@@ -1141,7 +1141,7 @@ private slots:
         QCOMPARE(model.data(model.index(6, 0), 0), "Token inserted 2");
 
         // source model matches proxy model
-        sourceModel.insertRows(5, {
+        sourceModel.insertTestRows(5, {
            { "title", { "Token inserted 1", "Token inserted 2"}},
            { "communityId", { "community_inserted_1", "community_inserted_2"}}
         });
@@ -1151,11 +1151,11 @@ private slots:
         QCOMPARE(sourceModel.data(sourceModel.index(5, 0), 1), "community_inserted_1");
         QCOMPARE(sourceModel.data(sourceModel.index(6, 0), 0), "Token inserted 2");
         QCOMPARE(sourceModel.data(sourceModel.index(6, 0), 1), "community_inserted_2");
-         
+
         QCOMPARE(model.dirty(), false);
         QCOMPARE(model.rowCount(), 7);
 
-        sourceModel.insertRows(2, {
+        sourceModel.insertTestRows(2, {
            { "title", { "Token 0.1", "Token 0.2"}},
            { "communityId", { "community_0.1", "community_0.2"}}
         });

--- a/toolkit/include/qtmodelstoolkit/leftjoinmodel.h
+++ b/toolkit/include/qtmodelstoolkit/leftjoinmodel.h
@@ -2,6 +2,7 @@
 
 #include <QAbstractListModel>
 #include <QPointer>
+#include <QCache>
 
 namespace qtmt {
 
@@ -21,6 +22,8 @@ class LeftJoinModel : public QAbstractListModel
     Q_PROPERTY(QStringList rolesToJoin READ rolesToJoin
                WRITE setRolesToJoin NOTIFY rolesToJoinChanged)
 
+    Q_PROPERTY(qsizetype cacheSize READ cacheSize WRITE setCacheSize NOTIFY cacheSizeChanged)
+
 public:
     explicit LeftJoinModel(QObject* parent = nullptr);
 
@@ -36,6 +39,9 @@ public:
     void setRolesToJoin(const QStringList& roles);
     const QStringList& rolesToJoin() const;
 
+    qsizetype cacheSize() const;
+    void setCacheSize(qsizetype size);
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
@@ -45,6 +51,7 @@ signals:
     void rightModelChanged();
     void joinRoleChanged();
     void rolesToJoinChanged();
+    void cacheSizeChanged();
 
 private:
     void initializeIfReady(bool reset);
@@ -52,6 +59,7 @@ private:
 
     void connectLeftModelSignals();
     void connectRightModelSignals();
+    void clearCache();
 
     int m_rightModelRolesOffset = 0;
     QHash<int, QByteArray> m_leftRoleNames;
@@ -70,7 +78,9 @@ private:
 
     bool m_initialized = false;
 
-    mutable QPersistentModelIndex m_lastUsedRightModelIndex;
+    // LRU cache for right model
+    qsizetype m_cacheSize = 1000;
+    mutable QCache<QVariant, QPersistentModelIndex> m_rightModelCache;
 
     // helpers for handling layoutChanged from source
     QList<QPersistentModelIndex> m_layoutChangePersistentIndexes;

--- a/toolkit/src/leftjoinmodel.cpp
+++ b/toolkit/src/leftjoinmodel.cpp
@@ -1,8 +1,47 @@
 #include "qtmodelstoolkit/leftjoinmodel.h"
 
 #include <QDebug>
+#include <QVariant>
 
 #include <algorithm>
+
+#include <QHash>
+#include <QMetaType>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+using qhash_result_t = uint;
+inline QMetaType::Type typeId(const QVariant &v) {
+    return static_cast<QMetaType::Type>(v.type());
+}
+#else
+using qhash_result_t = size_t;
+inline QMetaType::Type typeId(const QVariant &v) {
+    return static_cast<QMetaType::Type>(v.typeId());
+}
+#endif
+
+// for QCache to work with QVariant as a key.
+inline qhash_result_t qHash(const QVariant &v, qhash_result_t seed = 0)
+{
+    if (!v.isValid())
+        return seed;
+
+    switch (typeId(v)) {
+        case QMetaType::Int:
+            return ::qHash(v.toInt(), seed);
+        case QMetaType::UInt:
+            return ::qHash(v.toUInt(), seed);
+        case QMetaType::LongLong:
+            return ::qHash(v.toLongLong(), seed);
+        case QMetaType::ULongLong:
+            return ::qHash(v.toULongLong(), seed);
+        case QMetaType::QString:
+            return ::qHash(v.toString(), seed);
+        default:
+            // Fallback for other types, assuming they can be converted to a string representation.
+            return ::qHash(v.toString(), seed);
+    }
+}
 
 namespace qtmt {
 
@@ -20,6 +59,7 @@ namespace qtmt {
 LeftJoinModel::LeftJoinModel(QObject* parent)
     : QAbstractListModel{parent}
 {
+    m_rightModelCache.setMaxCost(m_cacheSize);
 }
 
 void LeftJoinModel::initializeIfReady(bool reset)
@@ -242,10 +282,12 @@ void LeftJoinModel::connectRightModelSignals()
                 role += m_rightModelRolesOffset;
         }
 
+        clearCache();
         emit dataChanged(index(0), index(rowCount() - 1), rolesTranslated);
     });
 
     auto emitJoinedRolesChanged = [this] {
+        clearCache();
         emit dataChanged(index(0), index(rowCount() - 1), m_joinedRoles);
     };
 
@@ -259,6 +301,7 @@ void LeftJoinModel::connectRightModelSignals()
     connect(m_rightModel, &QAbstractItemModel::modelReset, this, [this] () {
         m_initialized = false;
         m_roleNames = {};
+        clearCache();
         initializeIfReady(false);
 
         this->endResetModel();
@@ -280,11 +323,10 @@ QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
 
     auto joinRoleLeftValue = m_leftModel->data(idx, m_leftModelJoinRole);
 
-    if (m_lastUsedRightModelIndex.isValid()
-            && m_rightModel->data(m_lastUsedRightModelIndex,
-                                  m_rightModelJoinRole) == joinRoleLeftValue) {
-        return m_rightModel->data(m_lastUsedRightModelIndex,
-                                  role - m_rightModelRolesOffset);
+    if (auto cachedIndex = m_rightModelCache.object(joinRoleLeftValue)) {
+        if (cachedIndex->isValid()) {
+            return m_rightModel->data(*cachedIndex, role - m_rightModelRolesOffset);
+        }
     }
 
     QModelIndexList match = m_rightModel->match(
@@ -294,8 +336,10 @@ QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
     if (match.isEmpty())
         return {};
 
-    m_lastUsedRightModelIndex = match.constFirst();
-    return m_lastUsedRightModelIndex.data(role - m_rightModelRolesOffset);
+    QPersistentModelIndex persistentMatch = match.constFirst();
+    m_rightModelCache.insert(joinRoleLeftValue, new QPersistentModelIndex(persistentMatch));
+
+    return persistentMatch.data(role - m_rightModelRolesOffset);
 }
 
 void LeftJoinModel::setLeftModel(QAbstractItemModel* model)
@@ -311,6 +355,7 @@ void LeftJoinModel::setLeftModel(QAbstractItemModel* model)
     if (was_initialized) {
         beginResetModel();
         m_rolesFetched = false;
+        clearCache();
     }
 
     m_initialized = false;
@@ -359,6 +404,7 @@ void LeftJoinModel::setRightModel(QAbstractItemModel* model)
 
         m_rightModel = model;
         emit rightModelChanged();
+        clearCache();
 
         auto count = rowCount();
 
@@ -373,6 +419,7 @@ void LeftJoinModel::setRightModel(QAbstractItemModel* model)
     if (was_initialized) {
         beginResetModel();
         m_rolesFetched = false;
+        clearCache();
     }
 
     m_initialized = false;
@@ -453,6 +500,21 @@ const QStringList &LeftJoinModel::rolesToJoin() const
     return m_rolesToJoin;
 }
 
+qsizetype LeftJoinModel::cacheSize() const
+{
+    return m_cacheSize;
+}
+
+void LeftJoinModel::setCacheSize(qsizetype size)
+{
+    if (m_cacheSize == size)
+        return;
+
+    m_cacheSize = size;
+    m_rightModelCache.setMaxCost(m_cacheSize);
+    emit cacheSizeChanged();
+}
+
 int LeftJoinModel::rowCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
@@ -466,6 +528,11 @@ QHash<int, QByteArray> LeftJoinModel::roleNames() const
 {
     m_rolesFetched = true;
     return m_roleNames;
+}
+
+void LeftJoinModel::clearCache()
+{
+    m_rightModelCache.clear();
 }
 
 } // namespace qtmt


### PR DESCRIPTION
The right model data access is expensive because we need to search the right model for a matching key on every `data` call. This commit adds a LRU cache to the `data` call, storing by default up to 1000 indexes.

The cache mechanism uses a QCache for fast index lookup and a std::list to preserve the access order and to ensure a controlled cache removal.

+ fix compilation errors on ConcatModel and WritableProxyModel