### PR TITLE
chore: don't confuse Status translations with a dummy string

### DIFF
--- a/demoapp/main.qml
+++ b/demoapp/main.qml
@@ -6,7 +6,7 @@ ApplicationWindow {
     height: 768
 
     visible: true
-    title: qsTr("Hello World")
+    title: "Hello World"
 
     ListView {
         id: listView


### PR DESCRIPTION
- the string gets picked up randomly by the main status app `make update-translations`, remove it