### PR TITLE
chore: fix building against Qt 6.11

### DIFF
--- a/toolkit/src/modelentry.cpp
+++ b/toolkit/src/modelentry.cpp
@@ -18,7 +18,12 @@ namespace qtmt {
 */
 ModelEntry::ModelEntry(QObject* parent)
     : QObject(parent)
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+    , m_item(QQmlPropertyMap::create(this))
+#else
     , m_item(new QQmlPropertyMap(this))
+#endif
 { }
 
 /*!
@@ -334,7 +339,11 @@ void ModelEntry::resetItem()
         setAvailable(false);
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+    m_item.reset(QQmlPropertyMap::create());
+#else
     m_item.reset(new QQmlPropertyMap());
+#endif
 
     fillItem();
 

--- a/toolkit/src/objectproxymodel.cpp
+++ b/toolkit/src/objectproxymodel.cpp
@@ -265,7 +265,11 @@ QObject* ObjectProxyModel::proxyObject(int index) const
                              ? creationContext : m_delegate->engine()->rootContext();
 
     auto context = new QQmlContext(parentContext);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+    auto rowData = QQmlPropertyMap::create(context);
+#else
     auto rowData = new QQmlPropertyMap(context);
+#endif
     auto model = sourceModel();
 
     QHashIterator i(m_expectedRoleNames);


### PR DESCRIPTION
- use the static QQmlPropertyMap::create() method instead of the deprecated CTOR